### PR TITLE
feat: Improvements

### DIFF
--- a/.run/Run command (npm).run.xml
+++ b/.run/Run command (npm).run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run command (npm)" type="NodeJSConfigurationType" application-parameters="-f sample/auth-response.json token emailaddress servertime" path-to-js-file="./bin/jsonymize.mjs" working-dir="$PROJECT_DIR$">
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Run command _ cat.run.xml
+++ b/.run/Run command _ cat.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run command" type="ShConfigurationType">
+  <configuration default="false" name="Run command | cat" type="ShConfigurationType">
     <option name="SCRIPT_TEXT" value="cat sample/auth-response.json| npx jsonymize token emailaddress servertime" />
     <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
     <option name="SCRIPT_PATH" value="" />

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ npm install -g babel jsonymize
 
 ## Usage
 jsonymize reads data from standard input, anonymizes, then writes to
-standard output. By default all fields are anonymized, however, specific field
+standard output. By default, all fields are anonymized, however, specific field
 names can be passed as arguments as shown below.
 
 Choose fields to anonymize:

--- a/bin/jsonymize.mjs
+++ b/bin/jsonymize.mjs
@@ -11,6 +11,10 @@ import path from "path";
 
 let argv = yargs(process.argv.slice(2))
   .usage("Anonymize JSON values.\n\nUsage: $0 [fields]")
+  .options("f", {
+    alias: "file",
+    description: "JSON file whose content must be anonymized"
+  })
   .options("e", {
     alias: "extension",
     description: "ChanceJS mixin providing custom generators"
@@ -37,6 +41,7 @@ if (configPath && !fs.existsSync(configPath)) {
   exit(2);
 }
 
+const input = argv.f ? fs.createReadStream(argv.f) : stdin;
 const config = argv.config ? CJSON.load(argv.config) : {};
 const generators = argv.generator || config.generators || {};
 const extensions = fallback(argv.extension, relative(argv.config, config.extensions), []);
@@ -50,7 +55,7 @@ const anonymizer = new JsonymizeLib({
   extensions: extensions.map(_ => require(path.resolve(cwd(), _)))
 });
 
-anonymizer.anonymize(stdin).then(anonymized => {
+anonymizer.anonymize(input).then(anonymized => {
   stdout.write(`${JSON.stringify(anonymized)}\n`);
   exit(0);
 }).catch(error => {

--- a/lib/jsonymize-lib.mjs
+++ b/lib/jsonymize-lib.mjs
@@ -39,17 +39,28 @@ export default class JsonymizeLib {
 function findGenerators(chance, ...generators) {
   return generators
     .filter(value => value != null)
-    .map(name => ({name: name, generator: chance[name]}))
+    .map(name => ({ name: name, generator: chance[name] }))
     .filter(({ generator }) => Check.function(generator))
-    .map(({ name, generator }) => ({name: name, generator: generator.bind(chance)}));
+    .map(({ name, generator }) => ({ name: name, generator: generator.bind(chance) }));
 }
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const ipAddressRegex = /^(\d{1,3}\.){3}\d{1,3}$/;
+const timestampRegex = /^\d{10}$/;
+const guidRegex = /^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/;
+const hashRegex = /^[a-fA-F0-9]+$/;
 
 function types(value) {
   return [
     ["natural", Check.number],
     ["bool", Check.boolean],
-    ["string", Check.string],
     ["date", Check.date],
-    ["sentence", (value) => { Check.string(value) && value.includes(" ") }]
+    ["email", (value) => Check.string(value) && emailRegex.test(value)],
+    ["ip", (value) => Check.string(value) && ipAddressRegex.test(value)],
+    ["timestamp", (value) => Check.string(value) && timestampRegex.test(value)],
+    ["guid", (value) => Check.string(value) && guidRegex.test(value)],
+    ["hash", (value) => Check.string(value) && hashRegex.test(value)],
+    ["sentence", (value) => Check.string(value) && value.includes(" ")],
+    ["string", Check.string],
   ].map(([type, predicate]) => (predicate(value) ? type : undefined));
 }

--- a/lib/jsonymize-lib.mjs
+++ b/lib/jsonymize-lib.mjs
@@ -16,6 +16,8 @@ export default class JsonymizeLib {
     const chance = this[__chance__];
     const { aliases, fields, generators } = this[__options__];
 
+    const generatedValues = new Map();
+
     const actions = fields.reduce((result, alias) => {
       const field = aliases[alias] || alias;
       const isComplexOverride = Check.object(generators[alias]);
@@ -24,8 +26,17 @@ export default class JsonymizeLib {
 
       return Object.assign({}, result, {
         [field]: (value, path) => {
-          const generators = findGenerators(chance, generatorOverride, alias, field, ...types(value));
-          return generators.map(_ => _.generator(Object.assign({}, parameterOverride, { value: value })))[0];
+          if (generatedValues.has(value)) {
+            return generatedValues.get(value);
+          } else {
+            const generators = findGenerators(chance, generatorOverride, alias, field, ...types(value));
+            let anonymizedValue = generators
+              .map(_ => {
+                return _.generator(Object.assign({}, parameterOverride, { value: value }));
+              })[0];
+            generatedValues.set(value, anonymizedValue);
+            return anonymizedValue;
+          }
         }
       });
     }, {});
@@ -41,7 +52,9 @@ function findGenerators(chance, ...generators) {
     .filter(value => value != null)
     .map(name => ({ name: name, generator: chance[name] }))
     .filter(({ generator }) => Check.function(generator))
-    .map(({ name, generator }) => ({ name: name, generator: generator.bind(chance) }));
+    .map(({ name, generator }) => {
+      return ({ name: name, generator: generator.bind(chance) });
+    });
 }
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,22 +18,19 @@
       }
     },
     "chance": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/chance/-/chance-0.7.7.tgz",
-      "integrity": "sha512-ivWj+HFL9666WJGKqzxBfLzMcug4dT9Z70FDp7MHLFmfYdWsio4Mv228vuhmxW1Ra5XIwOrROa7yC74AdFgueA==",
-      "requires": {
-        "minimist": "^1.1.0"
-      }
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/chance/-/chance-1.1.11.tgz",
+      "integrity": "sha512-kqTg3WWywappJPqtgrdvbA380VoXO2eu9VCV895JgbyHsaErXdyHK9LOZ911OvAk6L0obK7kDk9CGs8+oBawVA=="
     },
     "check-types": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/check-types/-/check-types-3.3.1.tgz",
-      "integrity": "sha512-4JAbNHUt6JkOjCfMDbI2EzP9iq/EhgRntKO/muS8seNHfwI9cKIV5I6dAeE2US7svuON09PrWw0eT3A6KQf6tQ=="
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.2.2.tgz",
+      "integrity": "sha512-HBiYvXvn9Z70Z88XKjz3AEKd4HJhBXsa3j7xFnITAzoS8+q6eIGi8qDB8FKPBAjtuxjI/zFpwuiCb8oDtKOYrA=="
     },
     "cjson": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.3.tgz",
-      "integrity": "sha512-yKNcXi/Mvi5kb1uK0sahubYiyfUO2EUgOp4NcY9+8NX5Xmc+4yeNogZuLFkpLBBj7/QI9MjRUIuXrV9XOw5kVg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.5.0.tgz",
+      "integrity": "sha512-D3CKJU9YnZNyerUQ1IzNUvMnToP3MGC2XbIAPi/7yqunJJW3rBwCVapousoFtaR9IbejeEM0KIshxC1n4HQcXw==",
       "requires": {
         "json-parse-helpfulerror": "^1.0.3"
       }
@@ -98,11 +95,6 @@
       "requires": {
         "jju": "^1.1.0"
       }
-    },
-    "minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "oboe": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "url": "http://github.com/cameronhunter/jsonymize.git"
   },
   "dependencies": {
-    "chance": "~0.7.3",
-    "check-types": "~3.3.0",
-    "cjson": "~0.3.1",
+    "chance": "~1.1.11",
+    "check-types": "~11.2.2",
+    "cjson": "~0.5.0",
     "oboe": "~2.1.2",
     "yargs": "~17.7.2"
   },

--- a/sample/auth-response.json
+++ b/sample/auth-response.json
@@ -6,7 +6,7 @@
     "method": "auth.new",
     "clienttime": false,
     "servertime": "1679519482",
-    "authtoken": false,
+    "authtoken": "c3c9e664fdc1d7ab54cb3979f2879a7c2944a98adf3349130b4b4be74b6b34bc",
     "callback": false,
     "excludedeleted": false,
     "logbookdaysback": false,


### PR DESCRIPTION
Add some new features to jsonymize:
- file to anonymize can be passed directly to the command line with the `-f path/to/file` option. Default behavior is the original one using the standard input 
- strings should have the same format as the original when possible (email, ip address, timestamp, GUID, hash)
- if an original value is used in multiple places, the *same* anonymized value should be used in each place. This can be useful to keep relations between objects